### PR TITLE
Add CONFIG_SQUASHFS to prevent ubuntu server image first boot breakage.

### DIFF
--- a/conform_config.sh
+++ b/conform_config.sh
@@ -384,3 +384,9 @@ set_kernel_config CONFIG_DRM_VC4_HDMI_CEC y
 # required by PR#3144; should already be applied, but just to be safe
 set_kernel_config CONFIG_PCIE_BRCMSTB y
 set_kernel_config CONFIG_BCM2835_MMC y
+
+# Snap needs squashfs. The ubuntu eoan-preinstalled-server image at 
+# http://cdimage.ubuntu.com/ubuntu-server/daily-preinstalled/current/ uses snap
+# during cloud-init setup at first boot. Without this the login accounts are not
+# created and the user can not login.
+set_kernel_config CONFIG_SQUASHFS y


### PR DESCRIPTION
CONFIG_SQUASHFS is compiled in by default on the ubuntu raspi2 arm64 kernels, and is needed for snap to work.
Snap is required on the preinstalled-server images for initial boot login setup for the ubuntu user.

Ubuntu raspi2 arm64 defconfig is at https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/disco/tree/arch/arm64/configs/defconfig?h=raspi2