### PR TITLE
Adding Ceph support for RBD and FS.

### DIFF
--- a/conform_config.sh
+++ b/conform_config.sh
@@ -393,11 +393,11 @@ set_kernel_config CONFIG_SQUASHFS y
 
 # Ceph support for Block Device (RBD) and Filesystem (FS)
 # https://docs.ceph.com/docs/master/
-set_kernel_config CONFIG_CEPH_LIB=m
-set_kernel_config CONFIG_CEPH_LIB_USE_DNS_RESOLVER=y
-set_kernel_config CONFIG_CEPH_FS=m
-set_kernel_config CONFIG_CEPH_FSCACHE=y
-set_kernel_config CONFIG_CEPH_FS_POSIX_ACL=y
-set_kernel_config CONFIG_BLK_DEV_RBD=m
+set_kernel_config CONFIG_CEPH_LIB m
+set_kernel_config CONFIG_CEPH_LIB_USE_DNS_RESOLVER y
+set_kernel_config CONFIG_CEPH_FS m
+set_kernel_config CONFIG_CEPH_FSCACHE y
+set_kernel_config CONFIG_CEPH_FS_POSIX_ACL y
+set_kernel_config CONFIG_BLK_DEV_RBD m
 
 

--- a/conform_config.sh
+++ b/conform_config.sh
@@ -390,3 +390,14 @@ set_kernel_config CONFIG_BCM2835_MMC y
 # during cloud-init setup at first boot. Without this the login accounts are not
 # created and the user can not login.
 set_kernel_config CONFIG_SQUASHFS y
+
+# Ceph support for Block Device (RBD) and Filesystem (FS)
+# https://docs.ceph.com/docs/master/
+set_kernel_config CONFIG_CEPH_LIB=m
+set_kernel_config CONFIG_CEPH_LIB_USE_DNS_RESOLVER=y
+set_kernel_config CONFIG_CEPH_FS=m
+set_kernel_config CONFIG_CEPH_FSCACHE=y
+set_kernel_config CONFIG_CEPH_FS_POSIX_ACL=y
+set_kernel_config CONFIG_BLK_DEV_RBD=m
+
+


### PR DESCRIPTION
Ceph works well on ARM64, but kernel support is required. This adds support for the RBD and Filesystem components as modules. 